### PR TITLE
fix: feedback debug and handling common error in response

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -5,6 +5,11 @@ import "sync/atomic"
 // isDebug concurrent safe debug signal holder.
 var isDebug atomic.Bool
 
+// IsOn return the debug state, return true if it's on.
+func IsOn() bool {
+	return isDebug.Load()
+}
+
 // EnableDebug concurrent safe helper to enable debug information in the
 // stderr.
 func EnableDebug() {

--- a/debug/stack_trace_brispot.go
+++ b/debug/stack_trace_brispot.go
@@ -41,13 +41,12 @@ func GetStackTraceInString(pick ...int) string {
 		file, line := funcPtr.FileLine(stack[i])
 		if strings.Contains(file, "/app/") {
 
+			s := fmt.Sprintf("%s:%d\n", file, line)
 			// capture the matched pick
 			if !pickAll && trackPicked == pick[0] {
-				s := fmt.Sprintf("%s:%d %s\n", file, line, funcPtr.Name())
 				return s
 			}
 
-			s := fmt.Sprintf("%s:%d %s \n", file, line, funcPtr.Name())
 			allStackTrace.WriteString(s)
 
 			trackPicked++

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -17,7 +17,7 @@ func Recover(c http.Context) {
 	defer func() {
 		// grab any panic occurring
 		if r := recover(); r != nil {
-			m := log.Map{"msg": debug.GetStackTraceInString(1)}
+			m := log.Map{"panic": "error panic recovered", "msg": debug.GetStackTraceInString(1)}
 			log.Runtime(c).Error(m)
 
 			prefixMsg := "Runtime Error - "

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -20,8 +20,8 @@ func Recover(c http.Context) {
 			m := log.Map{"msg": debug.GetStackTraceInString(1)}
 			log.Runtime(c).Error(m)
 
-			prefixMsg := "Panic Runtime Error - "
-			suffixMsg := "Terjadi kesalahan, silahkan hubungi IT Helpdesk" // use masked message as the default
+			prefixMsg := "Runtime Error - "
+			suffixMsg := "Terjadi kesalahan, mohon coba beberapa saat lagi yaa..." // use masked message as the default
 			if facades.Config().GetBool("APP_DEBUG") {
 				// replace with the debug info if its enabled
 				suffixMsg = fmt.Sprint(r) + " - " + m["msg"].(string)

--- a/stdresp/option.go
+++ b/stdresp/option.go
@@ -3,6 +3,7 @@ package stdresp
 import (
 	"strings"
 
+	"github.com/spotlibs/go-lib/debug"
 	"github.com/spotlibs/go-lib/stderr"
 )
 
@@ -28,7 +29,7 @@ func WithErr(e error) StdOpt {
 	return func(s *Std) {
 		// set default response code and description
 		s.ResponseCode = stderr.ERROR_CODE_SYSTEM
-		s.ResponseDesc = stderr.ERROR_DESC_SYSTEM
+		s.ResponseDesc = "Terjadi kesalahan, mohon coba beberapa saat lagi yaa... "
 
 		// check if the error is created using stderr pkg
 		if stderr.IsStdError(e) {
@@ -43,6 +44,13 @@ func WithErr(e error) StdOpt {
 
 			// get the http code
 			s.httpCode = stderr.GetHttpCode(e)
+			return
+		}
+
+		// capture in case its random error that's not constructed with stderr pkg
+		//  but only print if the debug flag is on
+		if debug.IsOn() {
+			s.ResponseDesc = e.Error()
 		}
 	}
 }


### PR DESCRIPTION
- ref: remove function name from debug stack trace information
- ref: rename default error message as masking on recover middleware
- feat: add flagging to mark that this log come from recover middleware
- feat: capture common error in stdresp