### PR TITLE
fix: give default context when the input is nil

### DIFF
--- a/log/activity.go
+++ b/log/activity.go
@@ -29,6 +29,11 @@ func (l actLogger) Info(m Map) {
 
 // Activity start ActLogger.
 func Activity(c context.Context) ActLogger {
+	// prevent panic
+	if c == nil {
+		c = context.Background()
+	}
+
 	actOnce.Do(func() {
 		// setup log writer
 		actLogWriter := &writer{wr: setupLog("activity")}


### PR DESCRIPTION
- Fixing potential bug when the input context is nil in log activity