### PR TITLE
fix: wrong type on ToObject http client helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60.3
+          args: --timeout=30m

--- a/api/http_agent.go
+++ b/api/http_agent.go
@@ -38,10 +38,10 @@ func (r *response) GetHeaders() map[string]string {
 // using comma.
 func (r *response) GetHeader(key string) string { return strings.Join(r.header[key], ",") }
 
-// ToObject transform Response.Body to any object using json encoding.
-func ToObject[T any](obj response) (T, error) {
+// ToObject transform HTTPResponse.GetBody to any object using json encoding.
+func ToObject[T any](obj HTTPResponse) (T, error) {
 	var t T
-	return t, sonic.ConfigFastest.Unmarshal(obj.body, &t)
+	return t, sonic.ConfigFastest.Unmarshal(obj.GetBody(), &t)
 }
 
 type HTTPResponse interface {


### PR DESCRIPTION
- fix: wrong type to use as parameter on `ToObject` helper in http client pkg
- ci: increase linter timeout